### PR TITLE
Remove leading space from keywords.txt identifier

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,19 +7,19 @@
 #######################################
 
 HM62256	KEYWORD1
-address KEYWORD1
+address	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-get	    KEYWORD2
-set 	KEYWORD2
+get	KEYWORD2
+set	KEYWORD2
 clear	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
-HM62256_MEMORY_WIDTH    LITERAL1
-HM62256_DATA_WIDTH      LITERAL1
-HM62245_MEMORY_SIZE     LITERAL1
+HM62256_MEMORY_WIDTH	LITERAL1
+HM62256_DATA_WIDTH	LITERAL1
+HM62245_MEMORY_SIZE	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords